### PR TITLE
Remove s26-excl-nt path from in front of /api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY frontend/ ./
 
 # Build to /app/frontend/dist
 ARG PUBLIC_URL=/s26-excl-nt
-ARG API_BASE_URL=/s26-excl-nt/api
+ARG API_BASE_URL=/api
 ENV VITE_PUBLIC_URL=${PUBLIC_URL}
 ENV VITE_API_BASE_URL=${API_BASE_URL}
 RUN npm run build
@@ -24,7 +24,7 @@ RUN npm ci --omit=dev
 FROM node:22-alpine AS runtime
 ENV NODE_ENV=production
 ENV PUBLIC_URL=/s26-excl-nt
-ENV API_BASE_URL=/s26-excl-nt/api
+ENV API_BASE_URL=/api
 WORKDIR /app
 
 # Install PostgreSQL client (for pg_isready)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,16 +5,15 @@ services:
       args:
         # define public url and api base url for frontend build, SDP will use s26-excl-nt
         PUBLIC_URL: "${PUBLIC_URL:-/s26-excl-nt}"
-        API_BASE_URL: "${API_BASE_URL:-/s26-excl-nt/api}"
+        API_BASE_URL: "${API_BASE_URL:-/api}"
 
     environment:
-    
       NODE_ENV: production
       DB_HOST: postgres
       DB_USER: ${DB_USER}
       DB_PASS: ${DB_PASS}
       DB_NAME: ${DB_NAME}
-      API_BASE_URL: "${API_BASE_URL:-/s26-excl-nt/api}"       # must match build arg
+      API_BASE_URL: "${API_BASE_URL:-/api}"
       PUBLIC_URL: "${PUBLIC_URL:-/s26-excl-nt}"
 
     ports:


### PR DESCRIPTION
Removed /s26-excl-nt from in front of /api in both Dockerfile and docker-compose files