### PR TITLE
Updated docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY frontend/ ./
 
 # Build to /app/frontend/dist
 ARG PUBLIC_URL=/s26-excl-nt
-ARG API_BASE_URL=/api
+ARG API_BASE_URL=/s26-excl-nt/api
 ENV VITE_PUBLIC_URL=${PUBLIC_URL}
 ENV VITE_API_BASE_URL=${API_BASE_URL}
 RUN npm run build
@@ -18,7 +18,7 @@ RUN npm run build
 FROM node:22-alpine AS be-deps
 WORKDIR /app/backend
 COPY backend/package*.json ./
-RUN npm ci
+RUN npm ci --omit=dev
 
 # Final Runtime Stage
 FROM node:22-alpine AS runtime

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       args:
         # define public url and api base url for frontend build, SDP will use s26-excl-nt
         PUBLIC_URL: "${PUBLIC_URL:-/s26-excl-nt}"
-        API_BASE_URL: "${API_BASE_URL:-/api}"
+        API_BASE_URL: "${API_BASE_URL:-/s26-excl-nt/api}"
 
     environment:
       NODE_ENV: production
@@ -13,7 +13,7 @@ services:
       DB_USER: ${DB_USER}
       DB_PASS: ${DB_PASS}
       DB_NAME: ${DB_NAME}
-      API_BASE_URL: "${API_BASE_URL:-/api}"
+      API_BASE_URL: "${API_BASE_URL:-/s26-excl-nt/api}"
       PUBLIC_URL: "${PUBLIC_URL:-/s26-excl-nt}"
 
     ports:


### PR DESCRIPTION
Updated Docker files to include `/s26-excl-nt` in front of `/api`. This is in the hope that it will fix the routing issue with the server.