### PR TITLE
Closes #95

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,13 @@
 # React app HTML root URL
 PUBLIC_URL=/basename
 
+# Where the app is served (no trailing slash). Used only for absolute links in emails.
+# Example SDP deploy: PUBLIC_APP_ORIGIN=https://sdp.boisestate.edu
+# PUBLIC_APP_ORIGIN=
+
+# Optional: full login URL for emails (overrides PUBLIC_APP_ORIGIN + PUBLIC_URL).
+# LOGIN_PAGE_URL=https://sdp.boisestate.edu/basename/login
+
 # API Base URL
 API_BASE_URL=/basename/api
 

--- a/backend/src/services/email.js
+++ b/backend/src/services/email.js
@@ -44,6 +44,31 @@ const transporter =
     : null;
 
 /**
+ * Login URL for email bodies. Keep `PUBLIC_URL` as a pathname (e.g. /s26-excl-nt) for Express/Vite;
+ * set `PUBLIC_APP_ORIGIN` (e.g. https://sdp.boisestate.edu) so links work in mail clients.
+ * Optional `LOGIN_PAGE_URL` sets the full URL and overrides everything else.
+ */
+function getLoginPageUrl() {
+  const override = (process.env.LOGIN_PAGE_URL || "").trim().replace(/\/$/, "");
+  if (override) return override;
+
+  const publicPathRaw = (process.env.PUBLIC_URL || "").trim();
+  const publicPath = publicPathRaw.replace(/\/$/, "");
+
+  if (publicPath.startsWith("http://") || publicPath.startsWith("https://")) {
+    return `${publicPath}/login`;
+  }
+
+  const pathLogin = publicPath ? `${publicPath}/login` : "/login";
+  const origin = (process.env.PUBLIC_APP_ORIGIN || "").trim().replace(/\/$/, "");
+  if (origin) {
+    return `${origin}${pathLogin.startsWith("/") ? pathLogin : `/${pathLogin}`}`;
+  }
+
+  return pathLogin;
+}
+
+/**
  * Sends an email to a new user with login instructions.
  * Uses their email as the login identifier. Does not include the password (set by admin).
  *
@@ -53,8 +78,7 @@ const transporter =
  */
 async function sendLoginInfoEmail(toEmail, firstName, options = {}) {
   const { isResend = false } = options;
-  const baseUrl = (process.env.PUBLIC_URL || "").replace(/\/$/, "");
-  const loginUrl = baseUrl ? `${baseUrl}/login` : "/login";
+  const loginUrl = getLoginPageUrl();
   const appName = process.env.APP_NAME || "the application";
 
   const subject = isResend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       DB_NAME: ${DB_NAME}
       API_BASE_URL: "${API_BASE_URL:-/s26-excl-nt/api}"
       PUBLIC_URL: "${PUBLIC_URL:-/s26-excl-nt}"
+      PUBLIC_APP_ORIGIN: "${PUBLIC_APP_ORIGIN:-}"
       # SMTP config inside of Docker smtp variables added to backend
       SMTP_HOST: ${SMTP_HOST}
       SMTP_PORT: ${SMTP_PORT}


### PR DESCRIPTION
- backend/src/services/email.js now uses Nodemailer with SMTP_HOST/SMTP_PORT/SMTP_USER/SMTP_PASS and enforeces TLS
-  actually sends the login/notification emails not just logs
- works on the SDP server